### PR TITLE
Avoid routes being excluded in error

### DIFF
--- a/src/cloud-function/trmnl.py
+++ b/src/cloud-function/trmnl.py
@@ -191,7 +191,7 @@ def main(entur_stop: str = "NSR:StopPlace:58366", exclude_platforms: str = "", f
     sorted_items = sorted(grouped_data.items(), key=sort_key)  # returns list of tuples, [(Index, <Item>)]
 
     # Remove exclusion platforms
-    exclusion_platform_list = [p for p in exclude_platforms.split(',') if p]
+    exclusion_platform_list = [p.strip() for p in exclude_platforms.split(',') if p.strip()]
     cleaned_sorted_items = [item for item in sorted_items if item[0][2] not in exclusion_platform_list]
 
     # Generate departures json block in the format I want on trmnl

--- a/src/cloud-function/trmnl.py
+++ b/src/cloud-function/trmnl.py
@@ -191,7 +191,7 @@ def main(entur_stop: str = "NSR:StopPlace:58366", exclude_platforms: str = "", f
     sorted_items = sorted(grouped_data.items(), key=sort_key)  # returns list of tuples, [(Index, <Item>)]
 
     # Remove exclusion platforms
-    exclusion_platform_list = exclude_platforms.split(',')
+    exclusion_platform_list = [p for p in exclude_platforms.split(',') if p]
     cleaned_sorted_items = [item for item in sorted_items if item[0][2] not in exclusion_platform_list]
 
     # Generate departures json block in the format I want on trmnl


### PR DESCRIPTION
For some reason, some deptartures have "" as platforms instead of null. If the list of excluded platforms is empty, routes where the platform is "" will be excluded, as "".split(",") is "". It is possible to test this by finding a stop with problematic routes and changing the exlude platform list between an empty list and a non-existant platform.

Example: In the JSON below the bus to Lillestrøm will be shown, as the publicCode is null, but the tram line will not as the publicCode is "".
```
{
  "data": {
    "board1": [
      {
        "name": "Rosenhoff",
        "estimatedCalls": [
          {
            "destinationDisplay": { "frontText": "Lillestrøm" },
            "quay": {
              "id": "NSR:Quay:104045",
              "name": "Rosenhoff",
              "publicCode": null
            },
            "aimedDepartureTime": "2026-03-07T16:52:00+01:00",
            "expectedDepartureTime": "2026-03-07T16:52:00+01:00",
            "serviceJourney": {
              "journeyPattern": {
                "line": {
                  "id": "RUT:Line:380",
                  "publicCode": "380"
                }
              },
              "transportMode": "bus"
            }
          },
          {
            "destinationDisplay": { "frontText": "Sinsen-Grefsen st." },
            "quay": {
              "id": "NSR:Quay:11053",
              "name": "Rosenhoff",
              "publicCode": ""
            },
            "aimedDepartureTime": "2026-03-07T16:33:00+01:00",
            "expectedDepartureTime": "2026-03-07T16:33:27+01:00",
            "serviceJourney": {
              "journeyPattern": {
                "line": {
                  "id": "RUT:Line:17",
                  "publicCode": "17"
                }
              },
              "transportMode": "tram"
            }
          }
        ]
      }
    ]
  }
}